### PR TITLE
Make the Exchange Durable

### DIFF
--- a/atomresponder/master_importer.py
+++ b/atomresponder/master_importer.py
@@ -48,7 +48,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         ))
 
         channel = conn.channel()
-        channel.exchange_declare(settings.RABBITMQ_EXCHANGE, exchange_type="topic")
+        channel.exchange_declare(settings.RABBITMQ_EXCHANGE, exchange_type="topic", durable=True)
         channel.confirm_delivery()
 
         return conn, channel


### PR DESCRIPTION
## What does this change?

Makes the Rabbit MQ exchange for this software 'durable' so it will be retained on reboot of Rabbit MQ. The lack of the exchange has caused other parts of Pluto to completely refuse to start up.

## How can we measure success?

No more Pluto outages due to this issue.

## Have we considered potential risks?

For Pluto to correctly function, once the image containing this change has been deployed the exchange needs to be deleted so the software can start. Once this has been done, pluto-core and pluto-deliverbles-rabbitmq need to be restarted so they can mount the new exchange.

Tested on the dev. system.