### PR TITLE
Add Download Path to the Message

### DIFF
--- a/atomresponder/master_importer.py
+++ b/atomresponder/master_importer.py
@@ -53,7 +53,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
 
         return conn, channel
 
-    def update_pluto_record(self, item_id, job_id, content:dict, statinfo):
+    def update_pluto_record(self, item_id, job_id, content:dict, statinfo, download_path):
         (conn, channel) = self.setup_pika_channel()
 
         if 'type' not in content:
@@ -95,7 +95,8 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
             "itemId": item_id,
             "jobId": job_id,
             "commissionId": commission_id,
-            **statpart
+            **statpart,
+            "path": download_path
         }
 
         while True:
@@ -186,7 +187,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
             master_item = self.get_item_for_atomid(content['atomId'])
             if master_item is not None:
                 logger.info("Master item for atom already exists at {0}, assigning".format(master_item.name))
-                self.update_pluto_record(master_item.name, None, content, None)
+                self.update_pluto_record(master_item.name, None, content, None, None)
             else:
                 logger.warning("No master item exists for atom {0}.  Requesting a re-send from media atom tool".format(content['atomId']))
                 try:
@@ -325,7 +326,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
 
         statinfo = os.stat(downloaded_path)
 
-        self.update_pluto_record(vs_item_id, job_result.name, content, statinfo)
+        self.update_pluto_record(vs_item_id, job_result.name, content, statinfo, downloaded_path)
 
         try:
             logger.info("{n}: Looking for PAC info that has been already registered".format(n=vs_item_id))

--- a/atomresponder/tests/test_master_importer.py
+++ b/atomresponder/tests/test_master_importer.py
@@ -421,7 +421,7 @@ class TestMasterImporter(django.test.TestCase):
             with patch('atomresponder.master_importer.MasterImportResponder.setup_pika_channel',
                        return_value=(fake_connection, fake_channel)):
                 m = MasterImportResponder("fake role", "fake session", "fake stream", "shard-0000")
-                m.update_pluto_record("VX-123", "VX-456", content, None)
+                m.update_pluto_record("VX-123", "VX-456", content, None, None)
 
                 fake_channel.basic_publish.assert_called_once()
                 if "CI" in os.environ:


### PR DESCRIPTION
## What does this change?

Adds the download path to the RabbitMQ message.

Designed for use with this change to Pluto Deliverables: -

https://github.com/guardian/pluto-deliverables/pull/29

## How can we measure success?

The path is now present in the message.

Tested on the dev. system.
